### PR TITLE
update multi json to reflect the dependencies of cucumber

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,10 @@
 PATH
   remote: .
   specs:
-    cucumber_lint (0.1.2)
+    cucumber_lint (0.1.3)
       colorize (~> 0.7.7)
       gherkin (~> 2.12.2)
-      multi_json (~> 1.11.2)
+      multi_json (>= 1.7.5, < 2.0)
 
 GEM
   remote: http://rubygems.org/
@@ -80,4 +80,4 @@ DEPENDENCIES
   rubocop
 
 BUNDLED WITH
-   1.10.6
+   1.11.2

--- a/cucumber_lint.gemspec
+++ b/cucumber_lint.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'colorize', '~> 0.7.7'
   spec.add_runtime_dependency 'gherkin', '~> 2.12.2'
-  spec.add_runtime_dependency 'multi_json', '~> 1.11.2'
+  spec.add_runtime_dependency 'multi_json', '< 2.0', '>= 1.7.5'
 
   spec.files         = `git ls-files`.split("\n")
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/lib/cucumber_lint/version.rb
+++ b/lib/cucumber_lint/version.rb
@@ -1,3 +1,3 @@
 module CucumberLint # rubocop:disable Style/Documentation
-  VERSION = '0.1.2'
+  VERSION = '0.1.3'
 end


### PR DESCRIPTION
This now matches the multi_json dependencies of the edge version of [cucumber](https://rubygems.org/gems/cucumber/versions/2.4.0)